### PR TITLE
Fix trailing spaces in pihole.yaml

### DIFF
--- a/pihole/pihole.yaml
+++ b/pihole/pihole.yaml
@@ -76,7 +76,7 @@ spec:
         - name: WEBPASSWORD
           value: "YourSecurePassword" # Defina uma senha segura
         - name: VIRTUAL_HOST
-          value: "pihole.local"          
+          value: "pihole.local"
         volumeMounts:
         - name: pihole-data
           mountPath: /etc/pihole
@@ -145,7 +145,7 @@ spec:
     name: dns-tcp
   selector:
     app: pihole
----    
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Summary
- remove trailing whitespace from VIRTUAL_HOST line
- clean up stray whitespace before Ingress section

## Testing
- `yamllint pihole/pihole.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d07f5570832f993e4b13775193bd